### PR TITLE
Update Bundler Documentation

### DIFF
--- a/plugins/bundler.md
+++ b/plugins/bundler.md
@@ -19,3 +19,5 @@ When bundling `.ts` files to run in the browser, use a triple slash reference to
 
 document.getElementById("foo");
 ```
+
+This will help Deno and your code editor to Bundle into JS appropriately. 

--- a/plugins/bundler.md
+++ b/plugins/bundler.md
@@ -11,3 +11,11 @@ site.use(bundler());
 ```
 
 This plugin load `.js` and `.ts` files and output a single Javascript file including all dependencies of the input. Internally uses the [bundle](https://deno.land/manual/tools/bundler) Deno tool.
+
+When bundling `.ts` files to run in the browser, use a triple slash reference to include helpful libraries, like `dom` in your scripts. For example, 
+
+```
+/// <reference lib="dom" />
+
+document.getElementById("foo");
+```


### PR DESCRIPTION
What: Small update to documentation to reference triple slash directives. 

Why: If you write client scripts in Typescript to be bundled by Deno, it is essential to add a directive for common library APIs for the client runtime, "dom". This is mentioned in the Deno Manual but its way down there so I thought this would be helpful. 

I am using this to add a fuse based search box to my pages. 

