### PR TITLE
Update docs to the show cli commands rather than --flags

### DIFF
--- a/advanced/flags.md
+++ b/advanced/flags.md
@@ -28,7 +28,7 @@ const server = site.flags[0] || "server.com";
 site.script("deploy", `rsync -r _site/** user@${server}:/var/www/`);
 ```
 
-Now you can run `lume --run deploy` to deploy the site to the default server or `lume --run deploy -- other-server.com` to change the server name.
+Now you can run `lume run deploy` to deploy the site to the default server or `lume run deploy -- other-server.com` to change the server name.
 
 Because flags are stored in `site`, you can use it everywhere, for example in events:
 

--- a/advanced/scripts.md
+++ b/advanced/scripts.md
@@ -9,7 +9,7 @@ Lume includes a simple script runner that you can use to execute commands or cus
 site.script("deploy", "rsync -r _site/** user@server.com:/var/www/");
 ```
 
-Now, you can run this script from CLI with `lume --run deploy`.
+Now, you can run this script from CLI with `lume run deploy`.
 
 ## Running multiple commands
 
@@ -26,7 +26,7 @@ site.script(
 site.script("save-site", "gzip -r _site site.gz && scp site.gz user@host.com:/home/user/archive");
 ```
 
-Now, by running `lume --run save-site`, these two commands will be executed.
+Now, by running `lume run save-site`, these two commands will be executed.
 
 If you don't need to execute the commands in serie but in **parallel**, use an array of commands or the character `&`:
 

--- a/getting-started/1_installation.md
+++ b/getting-started/1_installation.md
@@ -28,5 +28,5 @@ Now you have the `lume` command. In the Deno manual you can see more info about 
 To update **lume** to the latest version you can execute:
 
 ```sh
-lume --upgrade
+lume upgrade
 ```

--- a/getting-started/2_command-line.md
+++ b/getting-started/2_command-line.md
@@ -7,16 +7,19 @@ These examples assume that you have installed lume as the `lume` executable:
 
 ```sh
 # Show the version
-lume --version (or -v)
+lume --version # or -v
 
 # Show help information
-lume --help (or -h)
+lume --help # or -h
+
+# Show help information for the build command
+lume build --help
 
 # Create a _config.js file
-lume --init
+lume init
 
 # Build the site in the current directory
-lume
+lume # or lume build
 
 # Build the site overriding some config values
 lume --src=from --dest=build --location=https://my-site.com/blog/
@@ -31,12 +34,12 @@ lume --serve
 # Change the web server port to localhost:8000
 lume --serve --port=8000
 
-# Run in development mode
+# Build in development mode to view draft pages
 lume --dev
 
-# Pass additional flags
+# Pass additional flags to your site code
 lume -- flag1 flag2
 
 # Run a custom script
-lume --run gzip
+lume run gzip
 ```

--- a/getting-started/3_config-file.md
+++ b/getting-started/3_config-file.md
@@ -10,7 +10,7 @@ You can customize this by adding a `_config.js` file, which adds to or overrides
 The config file must be placed in the site's root directory, and you can create it yourself or with the following command:
 
 ```sh
-lume --init
+lume init
 ```
 
 The `_config.js` file is a javascript module that exports the lume instance. The minimal required code is:


### PR DESCRIPTION
This is a sibling to https://github.com/lumeland/lume/pull/34.

Updating the lumeland site to show the command format implemented there.

Only merge this if/after that is merged.