### PR TITLE
update to psyche v0.3.2

### DIFF
--- a/_config.ts
+++ b/_config.ts
@@ -5,7 +5,7 @@ import basePath from "lume/plugins/base_path.ts";
 import resolveUrls from "lume/plugins/resolve_urls.ts";
 import anchor from "https://jspm.dev/markdown-it-anchor@8.0.0";
 import gpm from "https://deno.land/x/gpm@v0.4.1/mod.ts";
-import psyche from "https://deno.land/x/psyche@v0.3.1/indexers/lume.ts";
+import psyche from "https://deno.land/x/psyche@v0.3.2/indexers/lume.ts";
 
 const markdown = {
   plugins: [

--- a/js/scripts.js
+++ b/js/scripts.js
@@ -1,7 +1,7 @@
 import Navigator from "./vendor/page-loader/navigator.js";
 import psyche, {
   platformModifier,
-} from "https://deno.land/x/psyche@v0.3.1/client/psyche.min.mjs";
+} from "https://deno.land/x/psyche@v0.3.2/client/psyche.min.mjs";
 
 const menu = document.querySelector(".menu");
 const btn = document.querySelector(".menu-button");
@@ -59,7 +59,7 @@ const searchTheme = {
   searchTrigger = document.querySelector(".navbar-search");
 searchInstance.$component.addEventListener("click", (e) => {
   // route search results
-  const $a = e.composedPath().find(($) => $.matches("a"));
+  const $a = e.composedPath().find(($) => $ instanceof Element && $.matches("a"));
   if ($a) {
     e.preventDefault();
     nav.go($a.href);


### PR DESCRIPTION
fixes the styling issues discussed in https://github.com/dragonwocky/psyche/issues/2 and prevents an error triggered if a text node received a `click` event within the search component